### PR TITLE
Set CurrencyPrecision default value to 0

### DIFF
--- a/options.go
+++ b/options.go
@@ -8,7 +8,7 @@ type Options struct {
 	AutoPrint bool `json:"auto_print,omitempty"`
 
 	CurrencySymbol    string `default:"€ " json:"currency_symbol,omitempty"`
-	CurrencyPrecision int    `default:"2" json:"currency_precision,omitempty"`
+	CurrencyPrecision int    `default:"0" json:"currency_precision,omitempty"`
 	CurrencyDecimal   string `default:"." json:"currency_decimal,omitempty"`
 	CurrencyThousand  string `default:" " json:"currency_thousand,omitempty"`
 


### PR DESCRIPTION
since 0 for int means empty, 

```
&generator.Options{CurrencyPrecision: 0}
```

doesn't work unless we set the default value to 0